### PR TITLE
Change to use npm ci command instead of install so that dependencies are fresh

### DIFF
--- a/src/web-ui/buildspec.yml
+++ b/src/web-ui/buildspec.yml
@@ -7,7 +7,7 @@ phases:
     commands:
       - echo Installing NPM dependencies...
       - cd src/web-ui
-      - npm install
+      - npm ci
   build:
     commands:
       - chmod a+x ./gen_env.sh
@@ -17,7 +17,7 @@ phases:
   post_build:
     commands:
       - echo Uploading to ${WEB_BUCKET_NAME}
-      - aws s3 cp --recursive ./dist s3://${WEB_BUCKET_NAME}/ 
+      - aws s3 cp --recursive ./dist s3://${WEB_BUCKET_NAME}/
       - aws s3 cp --cache-control="max-age=0, no-cache, no-store, must-revalidate" ./dist/index.html s3://${WEB_BUCKET_NAME}/
       - aws cloudfront create-invalidation --distribution-id ${CLOUDFRONT_DIST_ID} --paths /index.html
 artifacts:


### PR DESCRIPTION


*Issue #, if available:*

*Description of changes:*

Change to use npm ci command instead of install so that dependencies are fresh.

See https://docs.npmjs.com/cli/v7/commands/npm-ci for more info.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
